### PR TITLE
Removing Sync trait requirement for generic 'F' in lib::TrayItem::add…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ impl TrayItem {
 
     pub fn add_menu_item<F>(&mut self, label: &str, cb: F) -> Result<(), TIError>
     where
-        F: Fn() + Send + Sync + 'static,
+        F: Fn() + Send + 'static,
     {
         self.0.add_menu_item(label, cb)
     }


### PR DESCRIPTION
…_menu_item to be able to compile for windows